### PR TITLE
Add support for Laravel > 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
   "keywords": ["laravel", "javascript", "language", "translations", "routes"],
   "type": "library",
   "require": {
-    "php": ">=5.5.9",
-    "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
+    "php": ">=7.1",
+    "illuminate/support": "^5.1"
   },
   "license": "MIT",
   "autoload": {


### PR DESCRIPTION
Card: https://podpoint.atlassian.net/browse/SWP-5141

In order to use this package after upgrading Partner Portal to L5.6, we need to change the semver rule for `illuminate/support` package, so it's supported up to L5.8.
