### PR TITLE
feat(OA-136): Supporting any laravel version till 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,9 @@
   "keywords": ["laravel", "javascript", "language", "translations", "routes"],
   "type": "library",
   "require": {
-    "php": ">=7.1",
-    "illuminate/support": "^5.1"
+    "php": "^7.1||^8.2",
+    "ext-json": "*",
+    "laravel/laravel": "^6.20||^7.30||^8.83||^9.52||^10.14"
   },
   "license": "MIT",
   "autoload": {

--- a/src/ViewComposers/ViewComposer.php
+++ b/src/ViewComposers/ViewComposer.php
@@ -38,7 +38,7 @@ class ViewComposer
      * @param  string $prefix
      * @return array
      */
-    private function transArray(array $array, $prefix)
+    private function transArray(array $array, string $prefix): array
     {
         $data = [];
 


### PR DESCRIPTION
- small type adjustment
- supporting any laravel version till 10 as translation functions are unchanged throwout
- changed dependencies from illuminaty/support to laravel/laravel as translation is part of the core modules