### PR TITLE
fix: dependency reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "require": {
     "php": "^7.1||^8.1||^8.2",
     "ext-json": "*",
-    "laravel/laravel": "^6.20||^7.30||^8.83||^9.52||^10.3"
+    "laravel/contracts": "^6.20||^7.30||^8.83||^9.52||^10.3",
+    "laravel/support": "^6.20||^7.30||^8.83||^9.52||^10.3"
   },
   "license": "MIT",
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "require": {
     "php": "^7.1||^8.1||^8.2",
     "ext-json": "*",
-    "laravel/contracts": "^6.20||^7.30||^8.83||^9.52||^10.3",
-    "laravel/support": "^6.20||^7.30||^8.83||^9.52||^10.3"
+    "illuminate/contracts": "^6.20||^7.30||^8.83||^9.52||^10.3",
+    "illuminate/support": "^6.20||^7.30||^8.83||^9.52||^10.3"
   },
   "license": "MIT",
   "autoload": {


### PR DESCRIPTION
- A Laravel package should never require `laravel/laravel` as this is a "dist" repo but instead should use sub-repositories such as `illuminate/*` otherwise this will cause the following warnings from `composer`

![image](https://github.com/Pod-Point/laravel-javascript-lang/assets/668419/02a8902a-b020-410f-8ac2-02cd6bb23e5d)
